### PR TITLE
Add note on net::ERR_BLOCKED_BY_CLIENT

### DIFF
--- a/grant-permissions-to-topotal-sre/README.md
+++ b/grant-permissions-to-topotal-sre/README.md
@@ -2,4 +2,6 @@
 
 Cloud Shellチュートリアルに沿ってコマンドを実行することで、Topotal SREに対して権限を付与することができます。
 
+ブラウザ側で `net::ERR_BLOCKED_BY_CLIENT` エラーが生じて Cloud Shell が起動しない場合は、広告をブロックするブラウザ拡張機能を無効化した上でアクセスしてください。
+
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftopotal%2Fsreaas-cloud-shell-tutorials&cloudshell_tutorial=grant-permissions-to-topotal-sre%2Fcloudshell-tutorial.md)

--- a/grant-permissions-to-topotal-sre/README.md
+++ b/grant-permissions-to-topotal-sre/README.md
@@ -2,6 +2,6 @@
 
 Cloud Shellチュートリアルに沿ってコマンドを実行することで、Topotal SREに対して権限を付与することができます。
 
-ブラウザ側で `net::ERR_BLOCKED_BY_CLIENT` エラーが生じて Cloud Shell が起動しない場合は、広告をブロックするブラウザ拡張機能を無効化した上でアクセスしてください。
+Cloud Shell が起動しない場合は、ブラウザのコンソール上で `net::ERR_BLOCKED_BY_CLIENT` エラーが生じているかどうかを確認してください。このエラー起因の問題は、広告をブロックするブラウザ拡張機能を無効化することで解決できます。
 
 [![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://shell.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https%3A%2F%2Fgithub.com%2Ftopotal%2Fsreaas-cloud-shell-tutorials&cloudshell_tutorial=grant-permissions-to-topotal-sre%2Fcloudshell-tutorial.md)


### PR DESCRIPTION
広告ブロックが有効になっているブラウザからCloud Shellを起動しようとした場合にアクセスできないケースがあったため対処法をREADMEに追加しました。